### PR TITLE
Fix GitHub Pages asset path issues

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Build for preview
         run: npm run build
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,15 @@
 import type { NextConfig } from "next";
 
+const isDevelopment = process.env.NODE_ENV !== 'production';
+const githubRepository = process.env.GITHUB_REPOSITORY;
+const basePath = isDevelopment || !githubRepository 
+  ? "" 
+  : `/${githubRepository.split('/')[1]}`;
+
 const nextConfig: NextConfig = {
   output: "export",
   trailingSlash: true,
+  basePath,
   images: {
     unoptimized: true,
   },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { LinkButton, Select, TextField } from "@/components";
 import Image from "next/image";
+import { getAssetPath } from "@/utils/asset-path";
 
 // Select options data
 const parallelWorldOptions = [
@@ -22,7 +23,7 @@ export default function Top() {
 
       {/* Main Visual Section */}
       <Image
-        src="/main-visual.webp"
+        src={getAssetPath("/main-visual.webp")}
         alt="起源肉体以上の駆動感。あなたの精神感応を最も高める電脳義体が分かる。"
         className="h-auto w-full"
         width={800}
@@ -77,13 +78,13 @@ export default function Top() {
           </p>
         </h2>
         <div className="flex flex-wrap items-center justify-center gap-5">
-          <Image src="/logo-1.webp" alt="Logo 1" width={101} height={45} />
-          <Image src="/logo-2.webp" alt="Logo 2" width={62} height={72} />
-          <Image src="/logo-3.webp" alt="Logo 3" width={119} height={47} />
-          <Image src="/logo-4.webp" alt="Logo 4" width={42} height={46} />
-          <Image src="/logo-5.webp" alt="Logo 5" width={74} height={35} />
-          <Image src="/logo-6.webp" alt="Logo 6" width={91} height={50} />
-          <Image src="/logo-7.webp" alt="Logo 7" width={40} height={44} />
+          <Image src={getAssetPath("/logo-1.webp")} alt="Logo 1" width={101} height={45} />
+          <Image src={getAssetPath("/logo-2.webp")} alt="Logo 2" width={62} height={72} />
+          <Image src={getAssetPath("/logo-3.webp")} alt="Logo 3" width={119} height={47} />
+          <Image src={getAssetPath("/logo-4.webp")} alt="Logo 4" width={42} height={46} />
+          <Image src={getAssetPath("/logo-5.webp")} alt="Logo 5" width={74} height={35} />
+          <Image src={getAssetPath("/logo-6.webp")} alt="Logo 6" width={91} height={50} />
+          <Image src={getAssetPath("/logo-7.webp")} alt="Logo 7" width={40} height={44} />
         </div>
         <LinkButton
           primaryLabel="資料請求の情報入力に進む"
@@ -105,7 +106,7 @@ export default function Top() {
           {/* Case 1 */}
           <div className="relative flex flex-col gap-y-4 rounded-md bg-white px-3 py-4">
             <Image
-              src="/user-1.webp"
+              src={getAssetPath("/user-1.webp")}
               alt=""
               width={192}
               height={192}
@@ -124,7 +125,7 @@ export default function Top() {
               </p>
             </div>
             <Image
-              src="/logo-2.webp"
+              src={getAssetPath("/logo-2.webp")}
               alt=""
               width={62}
               height={72}
@@ -134,7 +135,7 @@ export default function Top() {
           {/* Case 2 */}
           <div className="relative flex flex-col gap-y-4 rounded-md bg-white px-3 py-4">
             <Image
-              src="/user-2.webp"
+              src={getAssetPath("/user-2.webp")}
               alt=""
               width={192}
               height={192}
@@ -150,7 +151,7 @@ export default function Top() {
               </p>
             </div>
             <Image
-              src="/logo-6.webp"
+              src={getAssetPath("/logo-6.webp")}
               alt=""
               width={91}
               height={50}
@@ -160,7 +161,7 @@ export default function Top() {
           {/* Case 3 */}
           <div className="relative flex flex-col gap-y-4 rounded-md bg-white px-3 py-4">
             <Image
-              src="/user-3.webp"
+              src={getAssetPath("/user-3.webp")}
               alt=""
               width={192}
               height={192}
@@ -176,7 +177,7 @@ export default function Top() {
               </p>
             </div>
             <Image
-              src="/logo-7.webp"
+              src={getAssetPath("/logo-7.webp")}
               alt=""
               width={40}
               height={44}
@@ -202,7 +203,7 @@ export default function Top() {
           {/* Point 1 */}
           <div className="flex items-center gap-3 rounded border border-slate-300 bg-white">
             <Image
-              src="/point-1.webp"
+              src={getAssetPath("/point-1.webp")}
               alt=""
               width={100}
               height={100}
@@ -221,7 +222,7 @@ export default function Top() {
           {/* Point 2 */}
           <div className="flex items-center gap-3 rounded border border-slate-300 bg-white">
             <Image
-              src="/point-2.webp"
+              src={getAssetPath("/point-2.webp")}
               alt=""
               width={100}
               height={100}
@@ -242,7 +243,7 @@ export default function Top() {
           {/* Point 3 */}
           <div className="flex items-center gap-3 rounded border border-slate-300 bg-white">
             <Image
-              src="/point-3.webp"
+              src={getAssetPath("/point-3.webp")}
               alt=""
               width={100}
               height={100}

--- a/src/utils/asset-path.ts
+++ b/src/utils/asset-path.ts
@@ -1,0 +1,17 @@
+/**
+ * Get the correct asset path for images and other static assets.
+ * Automatically handles GitHub Pages basePath in production.
+ */
+export function getAssetPath(path: string): string {
+  if (process.env.NODE_ENV !== 'production') {
+    return path;
+  }
+  
+  const githubRepository = process.env.GITHUB_REPOSITORY;
+  if (!githubRepository) {
+    return path;
+  }
+  
+  const repoName = githubRepository.split('/')[1];
+  return `/${repoName}${path}`;
+}


### PR DESCRIPTION
## 概要

GitHub Pages でのホスティング時に画像が表示されない問題を修正しました。リポジトリ名を動的に取得することで、ハードコーディングを避けた汎用的な解決策を実装しています。

## 問題の詳細

- GitHub Pages では URL が `https://username.github.io/repository-name/` となり、リポジトリ名がベースパスに追加される
- 現在の画像パス（`/main-visual.webp` など）は絶対パスのため、`https://username.github.io/main-visual.webp` を参照してしまい 404 エラーが発生
- Next.js の `basePath` 設定を使用する場合、画像パスは手動で調整する必要がある

## 実装した解決策

### 1. 動的アセットパス管理ユーティリティ
- `src/utils/asset-path.ts` を新規作成
- `getAssetPath()` 関数で環境に応じて自動的にベースパスを付与
- 開発環境では元のパスをそのまま使用、本番環境では動的にリポジトリ名を追加

### 2. Next.js 設定の更新
- `next.config.ts` に環境変数ベースの動的 `basePath` 設定を追加
- `GITHUB_REPOSITORY` 環境変数からリポジトリ名を自動取得

### 3. GitHub Actions ワークフローの対応
- `.github/workflows/pr-preview.yml` でビルド時に `GITHUB_REPOSITORY` 環境変数を設定
- 既存のワークフローとの整合性を保持

### 4. 全画像パスの統一
- `src/app/page.tsx` 内の全17箇所の画像パスを `getAssetPath()` 関数に統一
- ハードコーディングされたパスを完全に排除

## テスト計画

- [x] ローカル開発環境での動作確認（`npm run dev`）
- [x] 本番ビルドの動作確認（`npm run build`）
- [ ] PR プレビューでの画像表示確認
- [ ] GitHub Pages での正常な画像読み込み確認

## メリット

✅ **保守性向上**: リポジトリ名の変更やフォーク時も自動対応  
✅ **開発効率**: 環境の違いを意識せずに開発可能  
✅ **拡張性**: 他の静的アセットにも同じパターンを適用可能  
✅ **型安全性**: TypeScript での型チェック対応

🤖 Generated with [Claude Code](https://claude.ai/code)