### PR TITLE
feat: ヘッダーに利用者数統計を追加

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,7 +2,7 @@ import Logo from "./Logo";
 
 const Header = () => {
   return (
-    <header className="flex items-center justify-between bg-white px-4 py-5">
+    <header className="flex items-center justify-between gap-4 bg-white px-4 py-5">
       <Logo className="h-3.5 w-auto" />
       <p className="text-xs font-medium text-sky-600 sm:text-sm">
         2025年7月時点で1,000万人以上のユーザー

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,8 +2,11 @@ import Logo from "./Logo";
 
 const Header = () => {
   return (
-    <header className="flex items-center justify-center bg-white px-4 py-5">
+    <header className="flex items-center justify-between bg-white px-4 py-5">
       <Logo className="h-3.5 w-auto" />
+      <p className="text-xs font-medium text-sky-600 sm:text-sm">
+        2025年7月時点で1,000万人以上のユーザー
+      </p>
     </header>
   );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,8 +4,8 @@ const Header = () => {
   return (
     <header className="flex items-center justify-between gap-4 bg-white px-4 py-5">
       <Logo className="h-3.5 w-auto" />
-      <p className="text-xs font-bold text-sky-600 sm:text-sm">
-        2025年7月時点で1,000万人以上のユーザー
+      <p className="text-xs font-bold text-sky-600 sm:text-sm wrap-anywhere break-keep">
+        2025年7月時点で<wbr />1,000万人以上のユーザー
       </p>
     </header>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,7 +4,7 @@ const Header = () => {
   return (
     <header className="flex items-center justify-between gap-4 bg-white px-4 py-5">
       <Logo className="h-3.5 w-auto" />
-      <p className="text-xs font-bold text-sky-600 sm:text-sm wrap-anywhere break-keep">
+      <p className="text-xs font-bold text-sky-600 sm:text-sm wrap-anywhere break-keep text-right">
         2025年7月時点で<wbr />1,000万人以上のユーザー
       </p>
     </header>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,7 +4,7 @@ const Header = () => {
   return (
     <header className="flex items-center justify-between gap-4 bg-white px-4 py-5">
       <Logo className="h-3.5 w-auto" />
-      <p className="text-xs font-medium text-sky-600 sm:text-sm">
+      <p className="text-xs font-bold text-sky-600 sm:text-sm">
         2025年7月時点で1,000万人以上のユーザー
       </p>
     </header>


### PR DESCRIPTION
## 概要
ヘッダーコンポーネントにユーザー統計情報を追加しました。

## 変更内容
- Header.tsx のレイアウトを `justify-center` から `justify-between` に変更
- ロゴの右側に「2025年7月時点で1,000万人以上のユーザー」という統計情報を表示
- レスポンシブ対応（text-xs → sm:text-sm）
- sky-600 カラーでスタイリング

## テスト計画
- [x] ヘッダーに統計情報が正しく表示されることを確認
- [x] レスポンシブデザインが適切に動作することを確認
- [x] 既存のロゴ表示に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)