### PR TITLE
docs: 日本語Webフォントのパフォーマンス最適化に関するコメント追加

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ import "./globals.css";
 const notoSansJP = Noto_Sans_JP({
   variable: "--font-noto-sans-jp",
   subsets: ["latin"],
-  weight: ["400", "700"],
+  weight: ["400", "700"], // 日本語Webフォントでたくさんのウェイトを使用すると非常に重くなるため、ウェイトは2つだけに制限。
 });
 
 export const metadata: Metadata = {


### PR DESCRIPTION
## 概要

Noto Sans JPフォントのウェイト制限について、パフォーマンス上の理由を明確にするコメントを追加しました。

## 変更内容

- `src/app/layout.tsx`のフォント設定にコメントを追加
- 400（通常）と700（太字）のみを使用する理由を説明

## 学習ポイント

### 🎯 パフォーマンス最適化
- **日本語Webフォントの容量問題**: 漢字を含むため欧文フォントより遥かに大きい
- **ウェイト制限の重要性**: 各ウェイトが独立したファイルとして読み込まれる
- **実用的な選択**: 通常（400）と太字（700）があれば大抵のデザインに対応可能

### 📚 知識の文書化
- **設計意図の明文化**: なぜその選択をしたのかを記録
- **将来の開発者への配慮**: 変更時の判断材料を提供
- **パフォーマンス意識の共有**: チーム全体の最適化意識向上

## テスト

- [x] コメントが正しく追加されることを確認
- [x] フォントの動作に影響がないことを確認
- [x] ビルドエラーがないことを確認

## 備考

この変更により、知識抽出システムが「日本語Webフォントの最適化パターン」として
学習し、今後の同様のパフォーマンス改善に活かされることが期待されます。

🤖 Generated with [Claude Code](https://claude.ai/code)